### PR TITLE
Add parse type [Any] with JsonValue

### DIFF
--- a/Stork/Stork/Source/JsonValue.swift
+++ b/Stork/Stork/Source/JsonValue.swift
@@ -25,6 +25,12 @@ public enum JsonValue {
       self = .string(value)
     case let value as JSON:
       self = .object(value)
+    case let value as [JsonValue]:
+      self = .array(value)
+    case let value as [Any]:
+      self = .array(value.map {
+        JsonValue.init(fromAny: $0)!
+      })
     default:
       return nil
     }
@@ -64,6 +70,16 @@ public enum JsonValue {
     switch self {
     case .object(let json):
       do { return try apply(json) }
+      catch { return nil }
+    default:
+      return nil
+    }
+  }
+
+  public func ifArray<T>(_ apply: ([JsonValue]) throws -> T?) -> T? {
+    switch self {
+    case .array(let jsonValue):
+      do { return try apply(jsonValue) }
       catch { return nil }
     default:
       return nil


### PR DESCRIPTION
Currently I can not see where JsonValue implements the array type. I see that it has a case for it, without supporting it in the init or the <type>If functions. 

This merge adds these two components. It allows traversal of input [Any]'s elements, and checks/converts the sub types to the appropriate format if possible.